### PR TITLE
Reduce Batch Sizing

### DIFF
--- a/tap_brightview/client.py
+++ b/tap_brightview/client.py
@@ -10,9 +10,6 @@ class HiveClient:
         self.sql = self.client.cursor()
 
     def setup_connection(self):
-        if jpype.isJVMStarted() and not jpype.isThreadAttachedToJVM():
-            jpype.attachThreadToJVM()
-            jpype.java.lang.Thread.currentThread().setContextClassLoader(jpype.java.lang.ClassLoader.getSystemClassLoader())
         connection = jaydebeapi.connect(
             "com.simba.hive.jdbc.HS2Driver",
             "jdbc:hive2://bdgw.qualifacts.org:443/brightview_prod;ssl=1;transportMode=http;httpPath=gateway/default/llap",

--- a/tap_brightview/streams.py
+++ b/tap_brightview/streams.py
@@ -59,14 +59,14 @@ class Stream():
                     yield row
 
                 if self.response_length < self.limit:
-                    # self.client.sql.close()
-                    # self.client.client.close()
                     LOGGER.info(f'{self.table_name} sync completed.')
                     LOGGER.info(
                         f'Creating bookmark for {self.tap_stream_id} stream in state.json')
 
             except Exception as e:
                 if e.getErrorCode() == 500593:
+                    client.sql.close()
+                    client.client.close()
                     LOGGER.info('Restarting Client')
                     restart_count += 1
                     singer.write_bookmark(self.state,
@@ -94,9 +94,9 @@ class Activity(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 
@@ -107,9 +107,9 @@ class ActivityLog(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 
@@ -120,9 +120,9 @@ class Address(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActProcMatrixDsc(IncrementalStream):
@@ -132,9 +132,9 @@ class ActProcMatrixDsc(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityDetail(IncrementalStream):
@@ -144,9 +144,9 @@ class ActivityDetail(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityDetailDsc(IncrementalStream):
@@ -156,9 +156,9 @@ class ActivityDetailDsc(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityDsc(IncrementalStream):
@@ -168,9 +168,9 @@ class ActivityDsc(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityError(IncrementalStream):
@@ -180,9 +180,9 @@ class ActivityError(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityProcedureAddon(IncrementalStream):
@@ -192,9 +192,9 @@ class ActivityProcedureAddon(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityProcedureClm(IncrementalStream):
@@ -204,9 +204,9 @@ class ActivityProcedureClm(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityProcedureClmMod(IncrementalStream):
@@ -216,9 +216,9 @@ class ActivityProcedureClmMod(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityProcedureMatrix(IncrementalStream):
@@ -228,9 +228,9 @@ class ActivityProcedureMatrix(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ActivityProgramMatrix(IncrementalStream):
@@ -240,9 +240,9 @@ class ActivityProgramMatrix(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Addendum(IncrementalStream):
@@ -252,9 +252,9 @@ class Addendum(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AdminCoPay(IncrementalStream):
@@ -264,9 +264,9 @@ class AdminCoPay(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AdminCoPayMatrix(IncrementalStream):
@@ -276,9 +276,9 @@ class AdminCoPayMatrix(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AdminCoPayMatrixLic(IncrementalStream):
@@ -288,9 +288,9 @@ class AdminCoPayMatrixLic(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AdminGroup(IncrementalStream):
@@ -300,9 +300,9 @@ class AdminGroup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AdminOrderStatus(IncrementalStream):
@@ -312,9 +312,9 @@ class AdminOrderStatus(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Alert(IncrementalStream):
@@ -324,9 +324,9 @@ class Alert(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AllergyEntry(IncrementalStream):
@@ -336,9 +336,9 @@ class AllergyEntry(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AuditDataedit(IncrementalStream):
@@ -348,9 +348,9 @@ class AuditDataedit(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AuditDeleteValues(IncrementalStream):
@@ -360,9 +360,9 @@ class AuditDeleteValues(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AuditLog(IncrementalStream):
@@ -372,9 +372,9 @@ class AuditLog(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AuditPageTitle(IncrementalStream):
@@ -384,9 +384,9 @@ class AuditPageTitle(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class AuditRowDelete(IncrementalStream):
@@ -396,9 +396,9 @@ class AuditRowDelete(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CashSheet(IncrementalStream):
@@ -408,9 +408,9 @@ class CashSheet(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CashSheetLine(IncrementalStream):
@@ -420,9 +420,9 @@ class CashSheetLine(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CfData(IncrementalStream):
@@ -432,9 +432,9 @@ class CfData(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CfDataHist(IncrementalStream):
@@ -444,9 +444,9 @@ class CfDataHist(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Claim(IncrementalStream):
@@ -456,9 +456,9 @@ class Claim(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimBatch(IncrementalStream):
@@ -468,9 +468,9 @@ class ClaimBatch(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimBatchLine(IncrementalStream):
@@ -480,9 +480,9 @@ class ClaimBatchLine(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimBillNext(IncrementalStream):
@@ -492,9 +492,9 @@ class ClaimBillNext(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimBillNextItem(IncrementalStream):
@@ -504,9 +504,9 @@ class ClaimBillNextItem(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimDiag(IncrementalStream):
@@ -516,9 +516,9 @@ class ClaimDiag(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimEngineRun(IncrementalStream):
@@ -528,9 +528,9 @@ class ClaimEngineRun(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimError(IncrementalStream):
@@ -540,9 +540,9 @@ class ClaimError(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimFollowupComment(IncrementalStream):
@@ -552,9 +552,9 @@ class ClaimFollowupComment(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimItem(IncrementalStream):
@@ -564,9 +564,9 @@ class ClaimItem(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimItemActivity(IncrementalStream):
@@ -576,9 +576,9 @@ class ClaimItemActivity(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimItemEditAudit(IncrementalStream):
@@ -588,9 +588,9 @@ class ClaimItemEditAudit(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimItemLine(IncrementalStream):
@@ -600,9 +600,9 @@ class ClaimItemLine(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimItemModifier(IncrementalStream):
@@ -612,9 +612,9 @@ class ClaimItemModifier(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimNote(IncrementalStream):
@@ -624,9 +624,9 @@ class ClaimNote(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimRollup(IncrementalStream):
@@ -636,9 +636,9 @@ class ClaimRollup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClaimValueCode(IncrementalStream):
@@ -648,9 +648,9 @@ class ClaimValueCode(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Client(IncrementalStream):
@@ -660,9 +660,9 @@ class Client(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientAllergy(IncrementalStream):
@@ -672,9 +672,9 @@ class ClientAllergy(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientAuthProcModif(IncrementalStream):
@@ -684,9 +684,9 @@ class ClientAuthProcModif(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientAuthProcedure(IncrementalStream):
@@ -696,9 +696,9 @@ class ClientAuthProcedure(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientBalance(IncrementalStream):
@@ -708,9 +708,9 @@ class ClientBalance(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientBlackBox(IncrementalStream):
@@ -720,9 +720,9 @@ class ClientBlackBox(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientBlackBoxStaff(IncrementalStream):
@@ -732,9 +732,9 @@ class ClientBlackBoxStaff(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientCoPay(IncrementalStream):
@@ -744,9 +744,9 @@ class ClientCoPay(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientCoPayMatrix(IncrementalStream):
@@ -756,9 +756,9 @@ class ClientCoPayMatrix(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientCoPayMatrixLic(IncrementalStream):
@@ -768,9 +768,9 @@ class ClientCoPayMatrixLic(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientConsent(IncrementalStream):
@@ -780,9 +780,9 @@ class ClientConsent(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientEpisode(IncrementalStream):
@@ -792,9 +792,9 @@ class ClientEpisode(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientEpisodeOrgMap(IncrementalStream):
@@ -804,9 +804,9 @@ class ClientEpisodeOrgMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientEpisodePrefs(IncrementalStream):
@@ -816,9 +816,9 @@ class ClientEpisodePrefs(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientEpisodeTriag(IncrementalStream):
@@ -828,9 +828,9 @@ class ClientEpisodeTriag(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientGroup(IncrementalStream):
@@ -840,9 +840,9 @@ class ClientGroup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientGuarantor(IncrementalStream):
@@ -852,9 +852,9 @@ class ClientGuarantor(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientGuarantorMix(IncrementalStream):
@@ -864,9 +864,9 @@ class ClientGuarantorMix(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientLiability(IncrementalStream):
@@ -876,9 +876,9 @@ class ClientLiability(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientLiabilityMem(IncrementalStream):
@@ -888,9 +888,9 @@ class ClientLiabilityMem(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientLiabilityMemExp(IncrementalStream):
@@ -900,9 +900,9 @@ class ClientLiabilityMemExp(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientMedication(IncrementalStream):
@@ -912,9 +912,9 @@ class ClientMedication(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientMessage(IncrementalStream):
@@ -924,9 +924,9 @@ class ClientMessage(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientPayerAuth(IncrementalStream):
@@ -936,9 +936,9 @@ class ClientPayerAuth(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientPayerPlan(IncrementalStream):
@@ -948,9 +948,9 @@ class ClientPayerPlan(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientPayerPlanDate(IncrementalStream):
@@ -960,9 +960,9 @@ class ClientPayerPlanDate(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientPcp(IncrementalStream):
@@ -972,9 +972,9 @@ class ClientPcp(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientPharmacy(IncrementalStream):
@@ -984,9 +984,9 @@ class ClientPharmacy(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientProgram(IncrementalStream):
@@ -996,9 +996,9 @@ class ClientProgram(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientProgramCode(IncrementalStream):
@@ -1008,9 +1008,9 @@ class ClientProgramCode(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientProgramDate(IncrementalStream):
@@ -1020,9 +1020,9 @@ class ClientProgramDate(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientProgramUnbillable(IncrementalStream):
@@ -1032,9 +1032,9 @@ class ClientProgramUnbillable(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientProvider(IncrementalStream):
@@ -1044,9 +1044,9 @@ class ClientProvider(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientRecordInv(IncrementalStream):
@@ -1056,9 +1056,9 @@ class ClientRecordInv(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientRecordInvChange(IncrementalStream):
@@ -1068,9 +1068,9 @@ class ClientRecordInvChange(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientRelationship(IncrementalStream):
@@ -1080,9 +1080,9 @@ class ClientRelationship(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientScannedDocument(IncrementalStream):
@@ -1092,9 +1092,9 @@ class ClientScannedDocument(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientSlidingScale(IncrementalStream):
@@ -1104,9 +1104,9 @@ class ClientSlidingScale(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientStaff(IncrementalStream):
@@ -1116,9 +1116,9 @@ class ClientStaff(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientView(IncrementalStream):
@@ -1128,9 +1128,9 @@ class ClientView(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClientViewAttempt(IncrementalStream):
@@ -1140,9 +1140,9 @@ class ClientViewAttempt(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClinicalRecon(IncrementalStream):
@@ -1152,9 +1152,9 @@ class ClinicalRecon(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClinicianAllergyEntry(IncrementalStream):
@@ -1164,9 +1164,9 @@ class ClinicianAllergyEntry(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClinicianOrdMedication(IncrementalStream):
@@ -1176,9 +1176,9 @@ class ClinicianOrdMedication(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ClinicianUser(IncrementalStream):
@@ -1188,9 +1188,9 @@ class ClinicianUser(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CodeSystem(IncrementalStream):
@@ -1200,9 +1200,9 @@ class CodeSystem(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CollectionAssignment(IncrementalStream):
@@ -1212,9 +1212,9 @@ class CollectionAssignment(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CollectionAssignmentClms(IncrementalStream):
@@ -1224,9 +1224,9 @@ class CollectionAssignmentClms(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CsBatch(IncrementalStream):
@@ -1236,9 +1236,9 @@ class CsBatch(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CsBatchClient(IncrementalStream):
@@ -1248,9 +1248,9 @@ class CsBatchClient(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CsBatchClientAging(IncrementalStream):
@@ -1260,9 +1260,9 @@ class CsBatchClientAging(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CsBatchClientClaim(IncrementalStream):
@@ -1272,9 +1272,9 @@ class CsBatchClientClaim(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class CsBatchClientClaimTran(IncrementalStream):
@@ -1284,9 +1284,9 @@ class CsBatchClientClaimTran(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Deposit(IncrementalStream):
@@ -1296,9 +1296,9 @@ class Deposit(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DepositActivity(IncrementalStream):
@@ -1308,9 +1308,9 @@ class DepositActivity(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DepositAudit(IncrementalStream):
@@ -1320,9 +1320,9 @@ class DepositAudit(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Descriptor(IncrementalStream):
@@ -1332,9 +1332,9 @@ class Descriptor(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DescriptorMappedValue(IncrementalStream):
@@ -1344,9 +1344,9 @@ class DescriptorMappedValue(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Document(IncrementalStream):
@@ -1356,9 +1356,9 @@ class Document(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DocumentAudit(IncrementalStream):
@@ -1368,9 +1368,9 @@ class DocumentAudit(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DocumentGrouping(IncrementalStream):
@@ -1380,9 +1380,9 @@ class DocumentGrouping(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DocumentSignature(IncrementalStream):
@@ -1392,9 +1392,9 @@ class DocumentSignature(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DocumentSignaturePad(IncrementalStream):
@@ -1404,9 +1404,9 @@ class DocumentSignaturePad(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DocumentStatus(IncrementalStream):
@@ -1416,9 +1416,9 @@ class DocumentStatus(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DsmDiagCategory(IncrementalStream):
@@ -1428,9 +1428,9 @@ class DsmDiagCategory(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DsmDiagCategoryRange(IncrementalStream):
@@ -1440,9 +1440,9 @@ class DsmDiagCategoryRange(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DsmDiagnosis(IncrementalStream):
@@ -1452,9 +1452,9 @@ class DsmDiagnosis(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class DynHcfa(IncrementalStream):
@@ -1464,9 +1464,9 @@ class DynHcfa(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi270Batch(IncrementalStream):
@@ -1476,9 +1476,9 @@ class Edi270Batch(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi270Detail(IncrementalStream):
@@ -1488,9 +1488,9 @@ class Edi270Detail(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi271(IncrementalStream):
@@ -1500,9 +1500,9 @@ class Edi271(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi271EbDates(IncrementalStream):
@@ -1512,9 +1512,9 @@ class Edi271EbDates(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi271Eligible(IncrementalStream):
@@ -1524,9 +1524,9 @@ class Edi271Eligible(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi271Reference(IncrementalStream):
@@ -1536,9 +1536,9 @@ class Edi271Reference(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi271RequestVal(IncrementalStream):
@@ -1548,9 +1548,9 @@ class Edi271RequestVal(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi271Subscriber(IncrementalStream):
@@ -1560,9 +1560,9 @@ class Edi271Subscriber(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi271SubscriberBenefit(IncrementalStream):
@@ -1572,9 +1572,9 @@ class Edi271SubscriberBenefit(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835(IncrementalStream):
@@ -1584,9 +1584,9 @@ class Edi835(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835AdjOrg(IncrementalStream):
@@ -1596,9 +1596,9 @@ class Edi835AdjOrg(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835AdjOrgMatrix(IncrementalStream):
@@ -1608,9 +1608,9 @@ class Edi835AdjOrgMatrix(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835AdjOrgPayerPlan(IncrementalStream):
@@ -1620,9 +1620,9 @@ class Edi835AdjOrgPayerPlan(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835Adjustment(IncrementalStream):
@@ -1632,9 +1632,9 @@ class Edi835Adjustment(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835AdjustmentReason(IncrementalStream):
@@ -1644,9 +1644,9 @@ class Edi835AdjustmentReason(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835Plb(IncrementalStream):
@@ -1656,9 +1656,9 @@ class Edi835Plb(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835Reference(IncrementalStream):
@@ -1668,9 +1668,9 @@ class Edi835Reference(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835Service(IncrementalStream):
@@ -1680,9 +1680,9 @@ class Edi835Service(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi835Transaction(IncrementalStream):
@@ -1692,9 +1692,9 @@ class Edi835Transaction(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi837(IncrementalStream):
@@ -1704,9 +1704,9 @@ class Edi837(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi837Element(IncrementalStream):
@@ -1716,9 +1716,9 @@ class Edi837Element(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Edi837Level(IncrementalStream):
@@ -1728,9 +1728,9 @@ class Edi837Level(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class EdiCode(IncrementalStream):
@@ -1740,9 +1740,9 @@ class EdiCode(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class EdiType(IncrementalStream):
@@ -1752,9 +1752,9 @@ class EdiType(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class EpisodeType(IncrementalStream):
@@ -1764,9 +1764,9 @@ class EpisodeType(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Error(IncrementalStream):
@@ -1776,9 +1776,9 @@ class Error(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxAllergy(IncrementalStream):
@@ -1788,9 +1788,9 @@ class ErxAllergy(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxClient(IncrementalStream):
@@ -1800,9 +1800,9 @@ class ErxClient(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxDrug(IncrementalStream):
@@ -1812,9 +1812,9 @@ class ErxDrug(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxMedication(IncrementalStream):
@@ -1824,9 +1824,9 @@ class ErxMedication(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxNotification(IncrementalStream):
@@ -1836,9 +1836,9 @@ class ErxNotification(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxPharmacy(IncrementalStream):
@@ -1848,9 +1848,9 @@ class ErxPharmacy(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxPrescription(IncrementalStream):
@@ -1860,9 +1860,9 @@ class ErxPrescription(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxPrescriptionStatus(IncrementalStream):
@@ -1872,9 +1872,9 @@ class ErxPrescriptionStatus(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ErxSig(IncrementalStream):
@@ -1884,9 +1884,9 @@ class ErxSig(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class FailedLogin(IncrementalStream):
@@ -1896,9 +1896,9 @@ class FailedLogin(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class FfsBatch(IncrementalStream):
@@ -1908,9 +1908,9 @@ class FfsBatch(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class FfsBatchLine(IncrementalStream):
@@ -1920,9 +1920,9 @@ class FfsBatchLine(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class FfsBatchLineErr(IncrementalStream):
@@ -1932,9 +1932,9 @@ class FfsBatchLineErr(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class FfsBatchLineHx(IncrementalStream):
@@ -1944,9 +1944,9 @@ class FfsBatchLineHx(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlCodeActivity(IncrementalStream):
@@ -1956,9 +1956,9 @@ class GlCodeActivity(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlCodeDate(IncrementalStream):
@@ -1968,9 +1968,9 @@ class GlCodeDate(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlCodeOrgProg(IncrementalStream):
@@ -1980,9 +1980,9 @@ class GlCodeOrgProg(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlCodeOrganization(IncrementalStream):
@@ -1992,9 +1992,9 @@ class GlCodeOrganization(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlCodePayer(IncrementalStream):
@@ -2004,9 +2004,9 @@ class GlCodePayer(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlCodePopulation(IncrementalStream):
@@ -2016,9 +2016,9 @@ class GlCodePopulation(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlCodeProgAct(IncrementalStream):
@@ -2028,9 +2028,9 @@ class GlCodeProgAct(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlCodeProgram(IncrementalStream):
@@ -2040,9 +2040,9 @@ class GlCodeProgram(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlDetail(IncrementalStream):
@@ -2052,9 +2052,9 @@ class GlDetail(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlError(IncrementalStream):
@@ -2064,9 +2064,9 @@ class GlError(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class GlMap(IncrementalStream):
@@ -2076,9 +2076,9 @@ class GlMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Guarantor(IncrementalStream):
@@ -2088,9 +2088,9 @@ class Guarantor(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class IntakeFollowup(IncrementalStream):
@@ -2100,9 +2100,9 @@ class IntakeFollowup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class IntakeTracking(IncrementalStream):
@@ -2112,9 +2112,9 @@ class IntakeTracking(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class IpLog(IncrementalStream):
@@ -2124,9 +2124,9 @@ class IpLog(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Licensure(IncrementalStream):
@@ -2136,9 +2136,9 @@ class Licensure(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Location(IncrementalStream):
@@ -2148,9 +2148,9 @@ class Location(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MacsisAdmDis(IncrementalStream):
@@ -2160,9 +2160,9 @@ class MacsisAdmDis(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MacsisAdmDisData(IncrementalStream):
@@ -2172,9 +2172,9 @@ class MacsisAdmDisData(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MacsisClientSigPad(IncrementalStream):
@@ -2184,9 +2184,9 @@ class MacsisClientSigPad(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MacsisEnrollmentForm(IncrementalStream):
@@ -2196,9 +2196,9 @@ class MacsisEnrollmentForm(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MacsisEnrollmentFormD(IncrementalStream):
@@ -2208,9 +2208,9 @@ class MacsisEnrollmentFormD(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MacsisEnrollmentVerify(IncrementalStream):
@@ -2220,9 +2220,9 @@ class MacsisEnrollmentVerify(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MasterModifier(IncrementalStream):
@@ -2232,9 +2232,9 @@ class MasterModifier(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MasterModifierDetail(IncrementalStream):
@@ -2244,9 +2244,9 @@ class MasterModifierDetail(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MasterModifierOrgMap(IncrementalStream):
@@ -2256,9 +2256,9 @@ class MasterModifierOrgMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MasterPersonIndex(IncrementalStream):
@@ -2268,9 +2268,9 @@ class MasterPersonIndex(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Measure(IncrementalStream):
@@ -2280,9 +2280,9 @@ class Measure(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MeasureQuestion(IncrementalStream):
@@ -2292,9 +2292,9 @@ class MeasureQuestion(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MeasureQuestionVal(IncrementalStream):
@@ -2304,9 +2304,9 @@ class MeasureQuestionVal(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MeasureSection(IncrementalStream):
@@ -2316,9 +2316,9 @@ class MeasureSection(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MeasureSubtotal(IncrementalStream):
@@ -2328,9 +2328,9 @@ class MeasureSubtotal(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Medication(IncrementalStream):
@@ -2340,9 +2340,9 @@ class Medication(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MedicationDispense(IncrementalStream):
@@ -2352,9 +2352,9 @@ class MedicationDispense(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MedicationEntry(IncrementalStream):
@@ -2364,9 +2364,9 @@ class MedicationEntry(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MedicationOrgMap(IncrementalStream):
@@ -2376,9 +2376,9 @@ class MedicationOrgMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Menu(IncrementalStream):
@@ -2388,9 +2388,9 @@ class Menu(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MenuOrgMap(IncrementalStream):
@@ -2400,9 +2400,9 @@ class MenuOrgMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MenuPriv(IncrementalStream):
@@ -2412,9 +2412,9 @@ class MenuPriv(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MenuSystem(IncrementalStream):
@@ -2424,9 +2424,9 @@ class MenuSystem(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MenuSystemOrgMap(IncrementalStream):
@@ -2436,9 +2436,9 @@ class MenuSystemOrgMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModCallLog(IncrementalStream):
@@ -2448,9 +2448,9 @@ class ModCallLog(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModEmploymt(IncrementalStream):
@@ -2460,9 +2460,9 @@ class ModEmploymt(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModEvalManagement(IncrementalStream):
@@ -2472,9 +2472,9 @@ class ModEvalManagement(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModGoalsAddrSummary(IncrementalStream):
@@ -2484,9 +2484,9 @@ class ModGoalsAddrSummary(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModLabResult(IncrementalStream):
@@ -2496,9 +2496,9 @@ class ModLabResult(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModLabResultDtl(IncrementalStream):
@@ -2508,9 +2508,9 @@ class ModLabResultDtl(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModLegal(IncrementalStream):
@@ -2520,9 +2520,9 @@ class ModLegal(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModLivingEd(IncrementalStream):
@@ -2532,9 +2532,9 @@ class ModLivingEd(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModManualMedRec(IncrementalStream):
@@ -2544,9 +2544,9 @@ class ModManualMedRec(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModMedDiagCat(IncrementalStream):
@@ -2556,9 +2556,9 @@ class ModMedDiagCat(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModMedication(IncrementalStream):
@@ -2568,9 +2568,9 @@ class ModMedication(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModMemoNote(IncrementalStream):
@@ -2580,9 +2580,9 @@ class ModMemoNote(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModPcpSignature(IncrementalStream):
@@ -2592,9 +2592,9 @@ class ModPcpSignature(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModPcpSignatureCbx(IncrementalStream):
@@ -2604,9 +2604,9 @@ class ModPcpSignatureCbx(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModReferral(IncrementalStream):
@@ -2616,9 +2616,9 @@ class ModReferral(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModServiceAddition(IncrementalStream):
@@ -2628,9 +2628,9 @@ class ModServiceAddition(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModServiceDetail(IncrementalStream):
@@ -2640,9 +2640,9 @@ class ModServiceDetail(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModServiceDetailSb(IncrementalStream):
@@ -2652,9 +2652,9 @@ class ModServiceDetailSb(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModSubAbuseDtlDsc(IncrementalStream):
@@ -2664,9 +2664,9 @@ class ModSubAbuseDtlDsc(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModSubstanceAbuse(IncrementalStream):
@@ -2676,9 +2676,9 @@ class ModSubstanceAbuse(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModSubstanceAbuseDate(IncrementalStream):
@@ -2688,9 +2688,9 @@ class ModSubstanceAbuseDate(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModSubstanceAbuseDsc(IncrementalStream):
@@ -2700,9 +2700,9 @@ class ModSubstanceAbuseDsc(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModSubstanceAbuseDtl(IncrementalStream):
@@ -2712,9 +2712,9 @@ class ModSubstanceAbuseDtl(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTedsNoms(IncrementalStream):
@@ -2724,9 +2724,9 @@ class ModTedsNoms(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTobacco(IncrementalStream):
@@ -2736,9 +2736,9 @@ class ModTobacco(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTplanEntity(IncrementalStream):
@@ -2748,9 +2748,9 @@ class ModTplanEntity(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTplanEntityDtl(IncrementalStream):
@@ -2760,9 +2760,9 @@ class ModTplanEntityDtl(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTplanEntityMap(IncrementalStream):
@@ -2772,9 +2772,9 @@ class ModTplanEntityMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTplanMaster(IncrementalStream):
@@ -2784,9 +2784,9 @@ class ModTplanMaster(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTransDischarge(IncrementalStream):
@@ -2796,9 +2796,9 @@ class ModTransDischarge(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxDiag(IncrementalStream):
@@ -2808,9 +2808,9 @@ class ModTxDiag(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxDiagAxis(IncrementalStream):
@@ -2820,9 +2820,9 @@ class ModTxDiagAxis(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxDx(IncrementalStream):
@@ -2832,9 +2832,9 @@ class ModTxDx(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxDxCode(IncrementalStream):
@@ -2844,9 +2844,9 @@ class ModTxDxCode(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxDxCodeSpecSev(IncrementalStream):
@@ -2856,9 +2856,9 @@ class ModTxDxCodeSpecSev(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxDxDiag(IncrementalStream):
@@ -2868,9 +2868,9 @@ class ModTxDxDiag(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxDxDiagSpecSev(IncrementalStream):
@@ -2880,9 +2880,9 @@ class ModTxDxDiagSpecSev(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxDxInfo(IncrementalStream):
@@ -2892,9 +2892,9 @@ class ModTxDxInfo(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlan(IncrementalStream):
@@ -2904,9 +2904,9 @@ class ModTxPlan(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlanClientProg(IncrementalStream):
@@ -2916,9 +2916,9 @@ class ModTxPlanClientProg(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlanEntity(IncrementalStream):
@@ -2928,9 +2928,9 @@ class ModTxPlanEntity(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlanEntityAct(IncrementalStream):
@@ -2940,9 +2940,9 @@ class ModTxPlanEntityAct(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlanEntityHx(IncrementalStream):
@@ -2952,9 +2952,9 @@ class ModTxPlanEntityHx(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlanEntityInfo(IncrementalStream):
@@ -2965,9 +2965,9 @@ class ModTxPlanEntityInfo(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlanInfo(IncrementalStream):
@@ -2978,9 +2978,9 @@ class ModTxPlanInfo(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlanNote(IncrementalStream):
@@ -2991,9 +2991,9 @@ class ModTxPlanNote(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModTxPlanNoteAddr(IncrementalStream):
@@ -3004,9 +3004,9 @@ class ModTxPlanNoteAddr(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ModVitals(IncrementalStream):
@@ -3017,9 +3017,9 @@ class ModVitals(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Module(IncrementalStream):
@@ -3030,9 +3030,9 @@ class Module(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvBillingError(IncrementalStream):
@@ -3042,9 +3042,9 @@ class MvBillingError(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvClaim(IncrementalStream):
@@ -3055,9 +3055,9 @@ class MvClaim(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvClient(IncrementalStream):
@@ -3067,9 +3067,9 @@ class MvClient(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvClientDiagnosis(IncrementalStream):
@@ -3079,9 +3079,9 @@ class MvClientDiagnosis(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvClientDocument(IncrementalStream):
@@ -3092,9 +3092,9 @@ class MvClientDocument(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvClientDsm5Diag(IncrementalStream):
@@ -3105,9 +3105,9 @@ class MvClientDsm5Diag(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvClientDsm5DiagDtl(IncrementalStream):
@@ -3118,9 +3118,9 @@ class MvClientDsm5DiagDtl(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvImpactData(IncrementalStream):
@@ -3131,9 +3131,9 @@ class MvImpactData(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvImpactDataResponse(IncrementalStream):
@@ -3144,9 +3144,9 @@ class MvImpactDataResponse(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvPayment(IncrementalStream):
@@ -3156,9 +3156,9 @@ class MvPayment(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvScheduledActivities(IncrementalStream):
@@ -3168,9 +3168,9 @@ class MvScheduledActivities(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvStaff(IncrementalStream):
@@ -3180,9 +3180,9 @@ class MvStaff(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class MvTransactions(IncrementalStream):
@@ -3192,9 +3192,9 @@ class MvTransactions(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class NonBillableFailedAct(IncrementalStream):
@@ -3204,9 +3204,9 @@ class NonBillableFailedAct(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class NonBillableFailedClaim(IncrementalStream):
@@ -3216,9 +3216,9 @@ class NonBillableFailedClaim(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrdCode(IncrementalStream):
@@ -3228,9 +3228,9 @@ class OrdCode(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrdGeneric(IncrementalStream):
@@ -3240,9 +3240,9 @@ class OrdGeneric(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrdLab(IncrementalStream):
@@ -3252,9 +3252,9 @@ class OrdLab(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrdLabClinician(IncrementalStream):
@@ -3264,9 +3264,9 @@ class OrdLabClinician(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrdLabClinicianTest(IncrementalStream):
@@ -3276,9 +3276,9 @@ class OrdLabClinicianTest(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrdMedication(IncrementalStream):
@@ -3288,9 +3288,9 @@ class OrdMedication(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrderConfigSetup(IncrementalStream):
@@ -3300,9 +3300,9 @@ class OrderConfigSetup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrderConfigType(IncrementalStream):
@@ -3312,9 +3312,9 @@ class OrderConfigType(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrderGroup(IncrementalStream):
@@ -3324,9 +3324,9 @@ class OrderGroup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrderMaster(IncrementalStream):
@@ -3336,9 +3336,9 @@ class OrderMaster(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrderMasterType(IncrementalStream):
@@ -3348,9 +3348,9 @@ class OrderMasterType(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrderModule(IncrementalStream):
@@ -3360,9 +3360,9 @@ class OrderModule(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrderModuleStatus(IncrementalStream):
@@ -3372,9 +3372,9 @@ class OrderModuleStatus(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Organization(IncrementalStream):
@@ -3384,9 +3384,9 @@ class Organization(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrganizationConfig(IncrementalStream):
@@ -3396,9 +3396,9 @@ class OrganizationConfig(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class OrganizationRelative(IncrementalStream):
@@ -3408,9 +3408,9 @@ class OrganizationRelative(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Payer(IncrementalStream):
@@ -3420,9 +3420,9 @@ class Payer(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerOrg(IncrementalStream):
@@ -3432,9 +3432,9 @@ class PayerOrg(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerPanel(IncrementalStream):
@@ -3444,9 +3444,9 @@ class PayerPanel(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerPanelOrgMap(IncrementalStream):
@@ -3456,9 +3456,9 @@ class PayerPanelOrgMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerPlan(IncrementalStream):
@@ -3468,9 +3468,9 @@ class PayerPlan(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerPlanBenefit(IncrementalStream):
@@ -3480,9 +3480,9 @@ class PayerPlanBenefit(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerPlanBenefitFee(IncrementalStream):
@@ -3492,9 +3492,9 @@ class PayerPlanBenefitFee(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerPlanConfig(IncrementalStream):
@@ -3504,9 +3504,9 @@ class PayerPlanConfig(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerPlanContact(IncrementalStream):
@@ -3516,9 +3516,9 @@ class PayerPlanContact(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerPlanOrg(IncrementalStream):
@@ -3528,9 +3528,9 @@ class PayerPlanOrg(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PayerProvider(IncrementalStream):
@@ -3540,9 +3540,9 @@ class PayerProvider(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PaymentActivity(IncrementalStream):
@@ -3552,9 +3552,9 @@ class PaymentActivity(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PaymentClaimAdjustment(IncrementalStream):
@@ -3564,9 +3564,9 @@ class PaymentClaimAdjustment(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PaymentDetail(IncrementalStream):
@@ -3577,9 +3577,9 @@ class PaymentDetail(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PaymentLine(IncrementalStream):
@@ -3589,9 +3589,9 @@ class PaymentLine(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PaymentPost(IncrementalStream):
@@ -3601,9 +3601,9 @@ class PaymentPost(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Person(IncrementalStream):
@@ -3613,9 +3613,9 @@ class Person(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PersonAddress(IncrementalStream):
@@ -3625,9 +3625,9 @@ class PersonAddress(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PersonAlias(IncrementalStream):
@@ -3637,9 +3637,9 @@ class PersonAlias(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PersonContact(IncrementalStream):
@@ -3649,9 +3649,9 @@ class PersonContact(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PersonContactPhone(IncrementalStream):
@@ -3661,9 +3661,9 @@ class PersonContactPhone(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PersonDemo(IncrementalStream):
@@ -3673,9 +3673,9 @@ class PersonDemo(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PersonDemoDscData(IncrementalStream):
@@ -3685,9 +3685,9 @@ class PersonDemoDscData(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PersonName(IncrementalStream):
@@ -3697,9 +3697,9 @@ class PersonName(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PersonReminderPref(IncrementalStream):
@@ -3709,9 +3709,9 @@ class PersonReminderPref(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class PrivilegeGroup(IncrementalStream):
@@ -3721,9 +3721,9 @@ class PrivilegeGroup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Procedure(IncrementalStream):
@@ -3733,9 +3733,9 @@ class Procedure(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ProcedureFee(IncrementalStream):
@@ -3745,9 +3745,9 @@ class ProcedureFee(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Program(IncrementalStream):
@@ -3757,9 +3757,9 @@ class Program(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ProgramOrgMap(IncrementalStream):
@@ -3769,9 +3769,9 @@ class ProgramOrgMap(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class QsiUser(IncrementalStream):
@@ -3781,9 +3781,9 @@ class QsiUser(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class QsiUserDate(IncrementalStream):
@@ -3793,9 +3793,9 @@ class QsiUserDate(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ReferralSource(IncrementalStream):
@@ -3805,9 +3805,9 @@ class ReferralSource(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Refund(IncrementalStream):
@@ -3817,9 +3817,9 @@ class Refund(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class RefundActivity(IncrementalStream):
@@ -3829,9 +3829,9 @@ class RefundActivity(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ScannedDocument(IncrementalStream):
@@ -3841,9 +3841,9 @@ class ScannedDocument(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ScannedDocumentKeyword(IncrementalStream):
@@ -3853,9 +3853,9 @@ class ScannedDocumentKeyword(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ServiceDoc(IncrementalStream):
@@ -3865,9 +3865,9 @@ class ServiceDoc(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ServiceDocMatrix(IncrementalStream):
@@ -3877,9 +3877,9 @@ class ServiceDocMatrix(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ServiceDocModule(IncrementalStream):
@@ -3889,9 +3889,9 @@ class ServiceDocModule(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ServiceDocReject(IncrementalStream):
@@ -3901,9 +3901,9 @@ class ServiceDocReject(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ServiceDocSetup(IncrementalStream):
@@ -3913,9 +3913,9 @@ class ServiceDocSetup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class ServiceLocationCode(IncrementalStream):
@@ -3925,9 +3925,9 @@ class ServiceLocationCode(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class SrpEpisode(IncrementalStream):
@@ -3937,9 +3937,9 @@ class SrpEpisode(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Staff(IncrementalStream):
@@ -3949,9 +3949,9 @@ class Staff(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StaffCredential(IncrementalStream):
@@ -3961,9 +3961,9 @@ class StaffCredential(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StaffCredentialPrimary(IncrementalStream):
@@ -3973,9 +3973,9 @@ class StaffCredentialPrimary(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StaffHistory(IncrementalStream):
@@ -3985,9 +3985,9 @@ class StaffHistory(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StaffHistoryData(IncrementalStream):
@@ -3997,9 +3997,9 @@ class StaffHistoryData(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StaffHistoryOrg(IncrementalStream):
@@ -4009,9 +4009,9 @@ class StaffHistoryOrg(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StaffPrivilege(IncrementalStream):
@@ -4021,9 +4021,9 @@ class StaffPrivilege(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StaffShift(IncrementalStream):
@@ -4033,9 +4033,9 @@ class StaffShift(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StaffSupervisoryGroup(IncrementalStream):
@@ -4045,9 +4045,9 @@ class StaffSupervisoryGroup(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StateReportingBatch(IncrementalStream):
@@ -4057,9 +4057,9 @@ class StateReportingBatch(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class StateReportingBatchDtl(IncrementalStream):
@@ -4069,9 +4069,9 @@ class StateReportingBatchDtl(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TranType(IncrementalStream):
@@ -4081,9 +4081,9 @@ class TranType(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TransReason(IncrementalStream):
@@ -4093,9 +4093,9 @@ class TransReason(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class Transaction(IncrementalStream):
@@ -4105,9 +4105,9 @@ class Transaction(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TransactionPeriod(IncrementalStream):
@@ -4117,9 +4117,9 @@ class TransactionPeriod(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TreatmentPlanGrid(IncrementalStream):
@@ -4129,9 +4129,9 @@ class TreatmentPlanGrid(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TreatmentPlanGridAssmt(IncrementalStream):
@@ -4141,9 +4141,9 @@ class TreatmentPlanGridAssmt(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TreatmentPlanGridDiag(IncrementalStream):
@@ -4153,9 +4153,9 @@ class TreatmentPlanGridDiag(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TreatmentPlanGridGoal(IncrementalStream):
@@ -4165,9 +4165,9 @@ class TreatmentPlanGridGoal(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TreatmentPlanGridLab(IncrementalStream):
@@ -4177,9 +4177,9 @@ class TreatmentPlanGridLab(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TreatmentPlanGridObj(IncrementalStream):
@@ -4189,9 +4189,9 @@ class TreatmentPlanGridObj(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TxPlanGridObjInt(IncrementalStream):
@@ -4201,9 +4201,9 @@ class TxPlanGridObjInt(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 class TxPlanGridSubProb(IncrementalStream):
@@ -4213,9 +4213,9 @@ class TxPlanGridSubProb(IncrementalStream):
     replication_method = 'INCREMENTAL'
     valid_replication_keys = ['last_operation_time']
     replication_key = 'last_operation_time'
-    response_length = 25000
+    response_length = 10000
     offset = 0
-    limit = 25000
+    limit = 10000
 
 
 


### PR DESCRIPTION
# Description :: User Story

When launched in K8s each time the client has to be refreshed it causes an increase in the base memory being used.  When a client does receive a `Connection Error` the client will close the cursor and connection and attempt to reconnect.  Also lowered the batch sizing (25k to 10k) in attempt to keep each client longer.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes
