### PR TITLE
Last Commit Time Restructure

### DIFF
--- a/tap_brightview/sync.py
+++ b/tap_brightview/sync.py
@@ -9,8 +9,8 @@ LOGGER = singer.get_logger()
 
 
 def sync(config, state, catalog, stream_collection):
-    # total_records = []
-    # stream_rps = []
+    total_records = []
+    stream_rps = []
 
     with Transformer() as transformer:
         for stream in catalog.get_selected_streams(state):
@@ -47,11 +47,12 @@ def sync(config, state, catalog, stream_collection):
             if records_written == 0:
                 LOGGER.info(f"No records found for {tap_stream_id}")
             else:
-                # info, rps = metrics(
-                #     start=start, end=time.perf_counter(), records=records_written
-                # )
-                # stream_rps.append(rps)
-                # LOGGER.info(f"{info}")
+                info, rps = metrics(
+                    start=start, end=time.perf_counter(), records=records_written
+                )
+                stream_rps.append(rps)
+                total_records.append(records_written)
+                LOGGER.info(f"{info}")
                 # singer.write_bookmark(state, tap_stream_id, "metrics", info)
 
                 singer.write_bookmark(
@@ -62,7 +63,8 @@ def sync(config, state, catalog, stream_collection):
                 )
 
     state = singer.set_currently_syncing(state, None)
-    # overall_rps = overall_metrics(total_records, stream_rps)
+    overall_rps = overall_metrics(total_records, stream_rps)
+    LOGGER.info(f"Records: {sum(total_records)} / RPS: {overall_rps:0.6}")
     # singer.write_bookmark(
     #     state,
     #     "Overall",


### PR DESCRIPTION
# Description :: Last Commit Time Structure

Brightview's vendor Qualifacts modified the database to have a consistent timestamp on the field of `last_commit_time` for incremental syncs.  These dates are added at 1970-01-01 (as a default time).  Due to this new timestamp the structure of the streams had to be modified to iterate off of this and then to correctly bookmark it as well.

This all so allowed new tables to be added to the batching groups.

259 tables are currently able to be sync'd.  Three local tests were run with various batch sizes (1, 5k, 10k) to ensure that data was pulled consistently.

**NOTE** Bookmarking has changed so a backfill will have to be sync'd so ensure no data is skipped

## Type of Change

- [x] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes