### PR TITLE
Remove Audit Log for separate backfill

### DIFF
--- a/tap_brightview/streams.py
+++ b/tap_brightview/streams.py
@@ -3206,7 +3206,7 @@ STREAMS_0 = {
     "allergy_entry": AllergyEntry,
     "audit_dataedit": AuditDataedit,
     "audit_delete_values": AuditDeleteValues,
-    "audit_log": AuditLog,
+    # "audit_log": AuditLog,
     "audit_page_title": AuditPageTitle,
     "audit_row_delete": AuditRowDelete,
     "cash_sheet": CashSheet,
@@ -3813,5 +3813,5 @@ STREAMS = [STREAMS_0, STREAMS_1, STREAMS_2, STREAMS_3, STREAMS_4, STREAMS_5, STR
     # "staff_history_data": StaffHistoryData,
     # "transaction_period": TransactionPeriod,
     # "treatment_plan_grid_assmt": TreatmentPlanGridAssmt,
-    # "treatment_plan_grid_lab": TreatmentPlanGridLab,
+    # "treatment_plan_grid_lab": TreatmentPlanGridLab
 # }


### PR DESCRIPTION
# Description :: User Story

Due to the size of the Audit Log table - it is being removed from the current historical sync batching and will needed to be addressed and batched in a different way.  Investigating incrementing off a separated unique field and then will sync separately

## Type of Change

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [ ] No Changes
