### PR TITLE
Remove slow down parameter

### DIFF
--- a/tap_brightview/client.py
+++ b/tap_brightview/client.py
@@ -17,7 +17,7 @@ class HiveClient:
         connection = jaydebeapi.connect(
             "com.simba.hive.jdbc.HS2Driver",
             "jdbc:hive2://bdgw.qualifacts.org:443/brightview_prod;ssl=1;transportMode=http;httpPath=gateway/default/llap",
-            {"user": self.BV_USER, "password": self.BV_PASSWORD, "dontTrackOpenResources": "true"},
+            [self.BV_USER, self.BV_PASSWORD],
             "./HiveJDBC42.jar",
         )
         return connection


### PR DESCRIPTION
Attempted a fix for the memory accumulation by adding a parameter to not track open resources.  This drastically reduced record pull time but had minimal affect on the resources used