### PR TITLE
Brightview Automated Audit Log

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap_brightview"
-version = "0.1.0"
+version = "1.1.0"
 description = ""
 authors = ["Jordan <jordan.wallace.williams@gmail.com>"]
 

--- a/tap_brightview/streams.py
+++ b/tap_brightview/streams.py
@@ -69,9 +69,9 @@ class Stream:
                         client.sql.close()
                         client.client.close()
                     
-                    if audit_record_count >= 12000000:
+                    if audit_record_count >= 12000000 and self.table_name == 'audit_log':
                         stream_finished = True
-                        LOGGER.info(f"{self.table_name} sync completed.")
+                        LOGGER.info(f"{self.table_name} sync batched at 12 million+ records.")
                         LOGGER.info(f"Creating bookmark for {self.tap_stream_id} stream")
                         client.sql.close()
                         client.client.close()


### PR DESCRIPTION
# Description :: User Story

After manual testing of larger tables the batch sizing for automated batching is set at 12 million records and bookmarked on access_datetime.

Set for sunday batching

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes
